### PR TITLE
Fix strict omit

### DIFF
--- a/src/types/strict-omit.ts
+++ b/src/types/strict-omit.ts
@@ -1,4 +1,4 @@
 export type StrictOmit<
-  Type extends Record<PropertyKey, unknown>,
+  Type,
   Keys extends keyof Type,
 > = Type extends ArrayLike<unknown> ? never : Omit<Type, Keys>


### PR DESCRIPTION
Makes `StrictOmit` work with all kinds of types. Previously it did not work with certain records that did not accept `symbol` as the index.